### PR TITLE
Fixed a bug caused by any other commit messages without ":"

### DIFF
--- a/tutorial-step-diff-compiler/package.js
+++ b/tutorial-step-diff-compiler/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:tutorial-step-diff-compiler',
-  version: '0.1.0',
+  version: '0.1.1',
   // Brief, one-line summary of the package.
   summary: 'Build plugin that parses git patches',
   // URL to the Git repository containing the source code for this package.

--- a/tutorial-step-diff-compiler/plugin.js
+++ b/tutorial-step-diff-compiler/plugin.js
@@ -29,6 +29,8 @@ function multiPatchHandler(compileStep) {
 function parseOutStepNumberAndComment(parsedPatch) {
   var splitMessage = parsedPatch.message.split(":");
 
-  parsedPatch.stepNumber = splitMessage[0].split(" ")[1].trim();
-  parsedPatch.summary = splitMessage[1].trim();
+  if (splitMessage.length > 1) {
+    parsedPatch.stepNumber = splitMessage[0].split(" ")[1].trim();
+    parsedPatch.summary = splitMessage[1].trim(); 
+  }
 }


### PR DESCRIPTION
In case that the repository have commits withouts ":" - the parser throws exception and does not parse the patch file. 
